### PR TITLE
Add landscape mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,6 @@
             android:name=".MainActivity"
             android:configChanges="locale|layoutDirection"
             android:exported="true"
-            android:screenOrientation="portrait"
             android:theme="@style/Theme.LibreSudoku">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/kaajjo/libresudoku/ui/components/board/Board.kt
+++ b/app/src/main/java/com/kaajjo/libresudoku/ui/components/board/Board.kt
@@ -7,11 +7,11 @@ import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -112,16 +112,23 @@ fun Board(
 ) {
     BoxWithConstraints(
         modifier = modifier
-            .fillMaxWidth()
             .aspectRatio(1f)
             .padding(4.dp)
     ) {
-        val maxWidth = constraints.maxWidth.toFloat()
+        val boxWithConstraintsScope = this
+
+        var maxWidth by remember { mutableFloatStateOf(boxWithConstraintsScope.constraints.maxWidth.toFloat()) }
 
         // single cell size
-        val cellSize by remember(size) { mutableFloatStateOf(maxWidth / size.toFloat()) }
+        var cellSize by remember(size) { mutableFloatStateOf(maxWidth / size.toFloat()) }
         // div for notes in one row in cell
-        val cellSizeDivWidth by remember(size) { mutableFloatStateOf(cellSize / ceil(sqrt(size.toFloat()))) }
+        var cellSizeDivWidth by remember(size) { mutableFloatStateOf(cellSize / ceil(sqrt(size.toFloat()))) }
+
+        SideEffect {
+            maxWidth = boxWithConstraintsScope.constraints.maxWidth.toFloat()
+            cellSize = maxWidth / size.toFloat()
+            cellSizeDivWidth = cellSize / ceil(sqrt(size.toFloat()))
+        }
 
         val errorColor = boardColors.errorColor
         val foregroundColor = boardColors.foregroundColor

--- a/app/src/main/java/com/kaajjo/libresudoku/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/kaajjo/libresudoku/ui/game/GameScreen.kt
@@ -1,5 +1,6 @@
 package com.kaajjo.libresudoku.ui.game
 
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.view.HapticFeedbackConstants
@@ -18,6 +19,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -51,6 +53,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
@@ -78,6 +81,7 @@ import com.kaajjo.libresudoku.ui.components.board.Board
 import com.kaajjo.libresudoku.ui.game.components.DefaultGameKeyboard
 import com.kaajjo.libresudoku.ui.game.components.GameMenu
 import com.kaajjo.libresudoku.ui.game.components.NotesMenu
+import com.kaajjo.libresudoku.ui.game.components.SquareGameKeyboard
 import com.kaajjo.libresudoku.ui.game.components.ToolBarItem
 import com.kaajjo.libresudoku.ui.game.components.ToolbarItem
 import com.kaajjo.libresudoku.ui.game.components.UndoRedoMenu
@@ -160,6 +164,8 @@ fun GameScreen(
         targetValue = if (viewModel.gamePlaying || viewModel.endGame) 1f else 0.90f,
         label = "Game board scale"
     )
+
+    var renderNotes by remember { mutableStateOf(true) }
 
     Scaffold(
         topBar = {
@@ -273,271 +279,560 @@ fun GameScreen(
             )
         }
     ) { scaffoldPaddings ->
-        Column(
-            modifier = Modifier
-                .padding(scaffoldPaddings)
-                .padding(horizontal = 12.dp),
-            verticalArrangement = Arrangement.SpaceEvenly
-        ) {
-            AnimatedVisibility(visible = !viewModel.endGame) {
-                Row(
+        val configuration = LocalConfiguration.current
+        val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+        if (isLandscape) {
+            Row(
+                modifier = Modifier
+                    .padding(scaffoldPaddings)
+                    .padding(horizontal = 12.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(fraction = 0.5f)
+                        .padding(horizontal = 12.dp)
+                        .padding(bottom = 8.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center)
+                    ) {
+                        AnimatedVisibility(
+                            visible = !viewModel.gamePlaying && !viewModel.endGame,
+                            enter = expandVertically(clip = false) + fadeIn(),
+                            exit = shrinkVertically(clip = false) + fadeOut()
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.PlayCircle,
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .shadow(12.dp)
+                            )
+                        }
+                    }
+                    Board(
+                        modifier = Modifier
+                            .blur(boardBlur)
+                            .scale(boardScale, boardScale),
+                        board = if (!viewModel.showSolution) viewModel.gameBoard else viewModel.solvedBoard,
+                        size = viewModel.size,
+                        mainTextSize = fontSizeValue,
+                        autoFontSize = fontSizeFactor == 0,
+                        notes = viewModel.notes,
+                        selectedCell = viewModel.currCell,
+                        onClick = { cell ->
+                            viewModel.processInput(
+                                cell = cell,
+                                remainingUse = remainingUse,
+                            )
+                            if (!viewModel.gamePlaying) {
+                                localView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                                viewModel.startTimer()
+                            }
+                        },
+                        onLongClick = { cell ->
+                            if (viewModel.processInput(cell, remainingUse, longTap = true)) {
+                                localView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                            }
+                        },
+                        identicalNumbersHighlight = highlightIdentical,
+                        errorsHighlight = errorHighlight != 0,
+                        positionLines = positionLines,
+                        notesToHighlight = if (viewModel.digitFirstNumber > 0) {
+                            viewModel.notes.filter { it.value == viewModel.digitFirstNumber }
+                        } else {
+                            emptyList()
+                        },
+                        enabled = viewModel.gamePlaying && !viewModel.endGame,
+                        questions = !(viewModel.gamePlaying || viewModel.endGame) && SDK_INT < Build.VERSION_CODES.R,
+                        renderNotes = renderNotes && !viewModel.showSolution,
+                        zoomable = viewModel.gameType == GameType.Default12x12 || viewModel.gameType == GameType.Killer12x12,
+                        crossHighlight = crossHighlight,
+                        cages = viewModel.cages,
+                        cellsToHighlight = if (advancedHintMode && advancedHintData != null) advancedHintData!!.helpCells + advancedHintData!!.targetCell else null
+                    )
+                }
+
+                AnimatedContent(advancedHintMode) { targetState ->
+                    if (targetState) {
+                        advancedHintData?.let { hintData ->
+                            AdvancedHintContainer(
+                                advancedHintData = hintData,
+                                onApplyClick = {
+                                    viewModel.applyAdvancedHint()
+                                },
+                                onBackClick = {
+                                    viewModel.cancelAdvancedHint()
+                                },
+                                onSettingsClick = {
+                                    navigator.navigate(
+                                        SettingsAdvancedHintScreenDestination
+                                    )
+                                }
+                            )
+                        }
+                        if (advancedHintData == null) {
+                            AdvancedHintContainer(
+                                advancedHintData = AdvancedHintData(
+                                    titleRes = R.string.advanced_hint_no_hint_title,
+                                    textResWithArg = Pair(
+                                        R.string.advanced_hint_no_hint,
+                                        emptyList()
+                                    ),
+                                    targetCell = Cell(-1, -1, 0),
+                                    helpCells = emptyList()
+                                ),
+                                onApplyClick = null,
+                                onBackClick = {
+                                    viewModel.cancelAdvancedHint()
+                                },
+                                onSettingsClick = {
+                                    navigator.navigate(
+                                        SettingsAdvancedHintScreenDestination
+                                    )
+                                }
+                            )
+                        }
+                    } else {
+                        AnimatedContent(!viewModel.endGame, label = "") { contentState ->
+                            if (contentState) {
+                                Column(
+                                    Modifier
+                                        .fillMaxSize()
+                                        .padding(bottom = 8.dp),
+                                    verticalArrangement = Arrangement.SpaceBetween
+                                ) {
+                                    AnimatedVisibility(visible = !viewModel.endGame) {
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth(),
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            horizontalArrangement = Arrangement.SpaceBetween
+                                        ) {
+                                            TopBoardSection(stringResource(viewModel.gameDifficulty.resName))
+
+                                            if (mistakesLimit && errorHighlight != 0) {
+                                                TopBoardSection(
+                                                    stringResource(
+                                                        R.string.mistakes_number_out_of,
+                                                        viewModel.mistakesCount,
+                                                        3
+                                                    )
+                                                )
+                                            }
+
+                                            val timerEnabled by viewModel.timerEnabled.collectAsStateWithLifecycle(
+                                                initialValue = PreferencesConstants.DEFAULT_SHOW_TIMER
+                                            )
+                                            AnimatedVisibility(visible = timerEnabled || viewModel.endGame) {
+                                                TopBoardSection(viewModel.timeText)
+                                            }
+                                        }
+                                    }
+                                    Column(
+                                        verticalArrangement = if (funKeyboardOverNum) ReverseArrangement else Arrangement.Top
+                                    ) {
+                                        SquareGameKeyboard(
+                                            size = viewModel.size,
+                                            remainingUses = if (remainingUse) viewModel.remainingUsesList else null,
+                                            onClick = {
+                                                viewModel.processInputKeyboard(number = it)
+                                            },
+                                            onLongClick = {
+                                                viewModel.processInputKeyboard(
+                                                    number = it,
+                                                    longTap = true
+                                                )
+                                            },
+                                            selected = viewModel.digitFirstNumber
+                                        )
+                                        Row(
+                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                            modifier = Modifier.padding(vertical = 8.dp)
+                                        ) {
+                                            Box(
+                                                modifier = Modifier.weight(1f)
+                                            ) {
+                                                UndoRedoMenu(
+                                                    expanded = viewModel.showUndoRedoMenu,
+                                                    onDismiss = {
+                                                        viewModel.showUndoRedoMenu = false
+                                                    },
+                                                    onRedoClick = {
+                                                        viewModel.toolbarClick(
+                                                            ToolBarItem.Redo
+                                                        )
+                                                    }
+                                                )
+                                                ToolbarItem(
+                                                    painter = painterResource(R.drawable.ic_round_undo_24),
+                                                    onClick = { viewModel.toolbarClick(ToolBarItem.Undo) },
+                                                    onLongClick = {
+                                                        viewModel.showUndoRedoMenu = true
+                                                    }
+                                                )
+
+                                            }
+                                            val hintsDisabled by viewModel.disableHints.collectAsStateWithLifecycle(
+                                                initialValue = PreferencesConstants.DEFAULT_HINTS_DISABLED
+                                            )
+                                            if (!hintsDisabled) {
+                                                ToolbarItem(
+                                                    modifier = Modifier.weight(1f),
+                                                    painter = painterResource(R.drawable.ic_lightbulb_stars_24),
+                                                    onClick = { viewModel.toolbarClick(ToolBarItem.Hint) }
+                                                )
+                                            }
+
+                                            Box(
+                                                modifier = Modifier.weight(1f)
+                                            ) {
+                                                NotesMenu(
+                                                    expanded = viewModel.showNotesMenu,
+                                                    onDismiss = { viewModel.showNotesMenu = false },
+                                                    onComputeNotesClick = { viewModel.computeNotes() },
+                                                    onClearNotesClick = { viewModel.clearNotes() },
+                                                    renderNotes = renderNotes,
+                                                    onRenderNotesClick = {
+                                                        renderNotes = !renderNotes
+                                                    }
+                                                )
+                                                ToolbarItem(
+                                                    painter = painterResource(R.drawable.ic_round_edit_24),
+                                                    toggled = viewModel.notesToggled,
+                                                    onClick = { viewModel.toolbarClick(ToolBarItem.Note) },
+                                                    onLongClick = {
+                                                        if (viewModel.gamePlaying) {
+                                                            localView.performHapticFeedback(
+                                                                HapticFeedbackConstants.VIRTUAL_KEY
+                                                            )
+                                                            viewModel.showNotesMenu = true
+                                                        }
+                                                    }
+                                                )
+
+                                            }
+                                            ToolbarItem(
+                                                modifier = Modifier.weight(1f),
+                                                painter = painterResource(R.drawable.ic_eraser_24),
+                                                toggled = viewModel.eraseButtonToggled,
+                                                onClick = {
+                                                    viewModel.toolbarClick(ToolBarItem.Remove)
+                                                },
+                                                onLongClick = {
+                                                    if (viewModel.gamePlaying) {
+                                                        localView.performHapticFeedback(
+                                                            HapticFeedbackConstants.VIRTUAL_KEY
+                                                        )
+                                                        viewModel.toggleEraseButton()
+                                                    }
+                                                }
+                                            )
+                                            if (advancedHintEnabled) {
+                                                ToolbarItem(
+                                                    modifier = Modifier.weight(1f),
+                                                    painter = rememberVectorPainter(Icons.Rounded.AutoAwesome),
+                                                    onClick = {
+                                                        if (viewModel.gamePlaying) {
+                                                            viewModel.getAdvancedHint()
+                                                        }
+                                                    }
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            } else {
+                                // Game completed section
+                                val allRecords by viewModel.allRecords.collectAsStateWithLifecycle(
+                                    initialValue = emptyList()
+                                )
+                                AfterGameStats(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    difficulty = viewModel.gameDifficulty,
+                                    type = viewModel.gameType,
+                                    hintsUsed = viewModel.hintsUsed,
+                                    mistakesMade = viewModel.mistakesMade,
+                                    mistakesLimit = mistakesLimit,
+                                    mistakesLimitCount = viewModel.mistakesCount,
+                                    giveUp = viewModel.giveUp,
+                                    notesTaken = viewModel.notesTaken,
+                                    records = allRecords,
+                                    timeText = viewModel.timeText
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .padding(scaffoldPaddings)
+                    .padding(horizontal = 12.dp),
+                verticalArrangement = Arrangement.SpaceEvenly
+            ) {
+                AnimatedVisibility(visible = !viewModel.endGame) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 24.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        TopBoardSection(stringResource(viewModel.gameDifficulty.resName))
+
+                        if (mistakesLimit && errorHighlight != 0) {
+                            TopBoardSection(
+                                stringResource(
+                                    R.string.mistakes_number_out_of,
+                                    viewModel.mistakesCount,
+                                    3
+                                )
+                            )
+                        }
+
+                        val timerEnabled by viewModel.timerEnabled.collectAsStateWithLifecycle(
+                            initialValue = PreferencesConstants.DEFAULT_SHOW_TIMER
+                        )
+                        AnimatedVisibility(visible = timerEnabled || viewModel.endGame) {
+                            TopBoardSection(viewModel.timeText)
+                        }
+                    }
+                }
+
+                Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 24.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween
+                        .padding(vertical = 12.dp)
                 ) {
-                    TopBoardSection(stringResource(viewModel.gameDifficulty.resName))
-
-                    if (mistakesLimit && errorHighlight != 0) {
-                        TopBoardSection(
-                            stringResource(
-                                R.string.mistakes_number_out_of,
-                                viewModel.mistakesCount,
-                                3
-                            )
-                        )
-                    }
-
-                    val timerEnabled by viewModel.timerEnabled.collectAsStateWithLifecycle(
-                        initialValue = PreferencesConstants.DEFAULT_SHOW_TIMER
-                    )
-                    AnimatedVisibility(visible = timerEnabled || viewModel.endGame) {
-                        TopBoardSection(viewModel.timeText)
-                    }
-                }
-            }
-
-            var renderNotes by remember { mutableStateOf(true) }
-
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 12.dp)
-            ) {
-                Column(
-                    modifier = Modifier.align(Alignment.Center)
-                ) {
-                    AnimatedVisibility(
-                        visible = !viewModel.gamePlaying && !viewModel.endGame,
-                        enter = expandVertically(clip = false) + fadeIn(),
-                        exit = shrinkVertically(clip = false) + fadeOut()
+                    Column(
+                        modifier = Modifier.align(Alignment.Center)
                     ) {
-                        Icon(
-                            imageVector = Icons.Rounded.PlayCircle,
-                            contentDescription = null,
-                            modifier = Modifier
-                                .size(48.dp)
-                                .shadow(12.dp)
-                        )
+                        AnimatedVisibility(
+                            visible = !viewModel.gamePlaying && !viewModel.endGame,
+                            enter = expandVertically(clip = false) + fadeIn(),
+                            exit = shrinkVertically(clip = false) + fadeOut()
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.PlayCircle,
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .shadow(12.dp)
+                            )
+                        }
                     }
+                    Board(
+                        modifier = Modifier
+                            .blur(boardBlur)
+                            .scale(boardScale, boardScale),
+                        board = if (!viewModel.showSolution) viewModel.gameBoard else viewModel.solvedBoard,
+                        size = viewModel.size,
+                        mainTextSize = fontSizeValue,
+                        autoFontSize = fontSizeFactor == 0,
+                        notes = viewModel.notes,
+                        selectedCell = viewModel.currCell,
+                        onClick = { cell ->
+                            viewModel.processInput(
+                                cell = cell,
+                                remainingUse = remainingUse,
+                            )
+                            if (!viewModel.gamePlaying) {
+                                localView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                                viewModel.startTimer()
+                            }
+                        },
+                        onLongClick = { cell ->
+                            if (viewModel.processInput(cell, remainingUse, longTap = true)) {
+                                localView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                            }
+                        },
+                        identicalNumbersHighlight = highlightIdentical,
+                        errorsHighlight = errorHighlight != 0,
+                        positionLines = positionLines,
+                        notesToHighlight = if (viewModel.digitFirstNumber > 0) {
+                            viewModel.notes.filter { it.value == viewModel.digitFirstNumber }
+                        } else {
+                            emptyList()
+                        },
+                        enabled = viewModel.gamePlaying && !viewModel.endGame,
+                        questions = !(viewModel.gamePlaying || viewModel.endGame) && SDK_INT < Build.VERSION_CODES.R,
+                        renderNotes = renderNotes && !viewModel.showSolution,
+                        zoomable = viewModel.gameType == GameType.Default12x12 || viewModel.gameType == GameType.Killer12x12,
+                        crossHighlight = crossHighlight,
+                        cages = viewModel.cages,
+                        cellsToHighlight = if (advancedHintMode && advancedHintData != null) advancedHintData!!.helpCells + advancedHintData!!.targetCell else null
+                    )
                 }
-                Board(
-                    modifier = Modifier
-                        .blur(boardBlur)
-                        .scale(boardScale, boardScale),
-                    board = if (!viewModel.showSolution) viewModel.gameBoard else viewModel.solvedBoard,
-                    size = viewModel.size,
-                    mainTextSize = fontSizeValue,
-                    autoFontSize = fontSizeFactor == 0,
-                    notes = viewModel.notes,
-                    selectedCell = viewModel.currCell,
-                    onClick = { cell ->
-                        viewModel.processInput(
-                            cell = cell,
-                            remainingUse = remainingUse,
-                        )
-                        if (!viewModel.gamePlaying) {
-                            localView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
-                            viewModel.startTimer()
-                        }
-                    },
-                    onLongClick = { cell ->
-                        if (viewModel.processInput(cell, remainingUse, longTap = true)) {
-                            localView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
-                        }
-                    },
-                    identicalNumbersHighlight = highlightIdentical,
-                    errorsHighlight = errorHighlight != 0,
-                    positionLines = positionLines,
-                    notesToHighlight = if (viewModel.digitFirstNumber > 0) {
-                        viewModel.notes.filter { it.value == viewModel.digitFirstNumber }
-                    } else {
-                        emptyList()
-                    },
-                    enabled = viewModel.gamePlaying && !viewModel.endGame,
-                    questions = !(viewModel.gamePlaying || viewModel.endGame) && SDK_INT < Build.VERSION_CODES.R,
-                    renderNotes = renderNotes && !viewModel.showSolution,
-                    zoomable = viewModel.gameType == GameType.Default12x12 || viewModel.gameType == GameType.Killer12x12,
-                    crossHighlight = crossHighlight,
-                    cages = viewModel.cages,
-                    cellsToHighlight = if (advancedHintMode && advancedHintData != null) advancedHintData!!.helpCells + advancedHintData!!.targetCell else null
-                )
-            }
 
-            AnimatedContent(advancedHintMode) { targetState ->
-                if (targetState) {
-                    advancedHintData?.let { hintData ->
-                        AdvancedHintContainer(
-                            advancedHintData = hintData,
-                            onApplyClick = {
-                                viewModel.applyAdvancedHint()
-                            },
-                            onBackClick = {
-                                viewModel.cancelAdvancedHint()
-                            },
-                            onSettingsClick = {
-                                navigator.navigate(
-                                    SettingsAdvancedHintScreenDestination
-                                )
-                            }
-                        )
-                    }
-                    if (advancedHintData == null) {
-                        AdvancedHintContainer(
-                            advancedHintData = AdvancedHintData(
-                                titleRes = R.string.advanced_hint_no_hint_title,
-                                textResWithArg = Pair(
-                                    R.string.advanced_hint_no_hint,
-                                    emptyList()
-                                ),
-                                targetCell = Cell(-1, -1, 0),
-                                helpCells = emptyList()
-                            ),
-                            onApplyClick = null,
-                            onBackClick = {
-                                viewModel.cancelAdvancedHint()
-                            },
-                            onSettingsClick = {
-                                navigator.navigate(
-                                    SettingsAdvancedHintScreenDestination
-                                )
-                            }
-                        )
-                    }
-                } else {
-                    AnimatedContent(!viewModel.endGame, label = "") { contentState ->
-                        if (contentState) {
-                            Column(
-                                verticalArrangement = if (funKeyboardOverNum) ReverseArrangement else Arrangement.Top
-                            ) {
-                                DefaultGameKeyboard(
-                                    size = viewModel.size,
-                                    remainingUses = if (remainingUse) viewModel.remainingUsesList else null,
-                                    onClick = {
-                                        viewModel.processInputKeyboard(number = it)
-                                    },
-                                    onLongClick = {
-                                        viewModel.processInputKeyboard(
-                                            number = it,
-                                            longTap = true
-                                        )
-                                    },
-                                    selected = viewModel.digitFirstNumber
-                                )
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                    modifier = Modifier.padding(vertical = 8.dp)
-                                ) {
-                                    Box(
-                                        modifier = Modifier.weight(1f)
-                                    ) {
-                                        UndoRedoMenu(
-                                            expanded = viewModel.showUndoRedoMenu,
-                                            onDismiss = { viewModel.showUndoRedoMenu = false },
-                                            onRedoClick = { viewModel.toolbarClick(ToolBarItem.Redo) }
-                                        )
-                                        ToolbarItem(
-                                            painter = painterResource(R.drawable.ic_round_undo_24),
-                                            onClick = { viewModel.toolbarClick(ToolBarItem.Undo) },
-                                            onLongClick = { viewModel.showUndoRedoMenu = true }
-                                        )
-
-                                    }
-                                    val hintsDisabled by viewModel.disableHints.collectAsStateWithLifecycle(
-                                        initialValue = PreferencesConstants.DEFAULT_HINTS_DISABLED
+                AnimatedContent(advancedHintMode) { targetState ->
+                    if (targetState) {
+                        advancedHintData?.let { hintData ->
+                            AdvancedHintContainer(
+                                advancedHintData = hintData,
+                                onApplyClick = {
+                                    viewModel.applyAdvancedHint()
+                                },
+                                onBackClick = {
+                                    viewModel.cancelAdvancedHint()
+                                },
+                                onSettingsClick = {
+                                    navigator.navigate(
+                                        SettingsAdvancedHintScreenDestination
                                     )
-                                    if (!hintsDisabled) {
+                                }
+                            )
+                        }
+                        if (advancedHintData == null) {
+                            AdvancedHintContainer(
+                                advancedHintData = AdvancedHintData(
+                                    titleRes = R.string.advanced_hint_no_hint_title,
+                                    textResWithArg = Pair(
+                                        R.string.advanced_hint_no_hint,
+                                        emptyList()
+                                    ),
+                                    targetCell = Cell(-1, -1, 0),
+                                    helpCells = emptyList()
+                                ),
+                                onApplyClick = null,
+                                onBackClick = {
+                                    viewModel.cancelAdvancedHint()
+                                },
+                                onSettingsClick = {
+                                    navigator.navigate(
+                                        SettingsAdvancedHintScreenDestination
+                                    )
+                                }
+                            )
+                        }
+                    } else {
+                        AnimatedContent(!viewModel.endGame, label = "") { contentState ->
+                            if (contentState) {
+                                Column(
+                                    verticalArrangement = if (funKeyboardOverNum) ReverseArrangement else Arrangement.Top
+                                ) {
+                                    DefaultGameKeyboard(
+                                        size = viewModel.size,
+                                        remainingUses = if (remainingUse) viewModel.remainingUsesList else null,
+                                        onClick = {
+                                            viewModel.processInputKeyboard(number = it)
+                                        },
+                                        onLongClick = {
+                                            viewModel.processInputKeyboard(
+                                                number = it,
+                                                longTap = true
+                                            )
+                                        },
+                                        selected = viewModel.digitFirstNumber
+                                    )
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                        modifier = Modifier.padding(vertical = 8.dp)
+                                    ) {
+                                        Box(
+                                            modifier = Modifier.weight(1f)
+                                        ) {
+                                            UndoRedoMenu(
+                                                expanded = viewModel.showUndoRedoMenu,
+                                                onDismiss = { viewModel.showUndoRedoMenu = false },
+                                                onRedoClick = { viewModel.toolbarClick(ToolBarItem.Redo) }
+                                            )
+                                            ToolbarItem(
+                                                painter = painterResource(R.drawable.ic_round_undo_24),
+                                                onClick = { viewModel.toolbarClick(ToolBarItem.Undo) },
+                                                onLongClick = { viewModel.showUndoRedoMenu = true }
+                                            )
+
+                                        }
+                                        val hintsDisabled by viewModel.disableHints.collectAsStateWithLifecycle(
+                                            initialValue = PreferencesConstants.DEFAULT_HINTS_DISABLED
+                                        )
+                                        if (!hintsDisabled) {
+                                            ToolbarItem(
+                                                modifier = Modifier.weight(1f),
+                                                painter = painterResource(R.drawable.ic_lightbulb_stars_24),
+                                                onClick = { viewModel.toolbarClick(ToolBarItem.Hint) }
+                                            )
+                                        }
+
+                                        Box(
+                                            modifier = Modifier.weight(1f)
+                                        ) {
+                                            NotesMenu(
+                                                expanded = viewModel.showNotesMenu,
+                                                onDismiss = { viewModel.showNotesMenu = false },
+                                                onComputeNotesClick = { viewModel.computeNotes() },
+                                                onClearNotesClick = { viewModel.clearNotes() },
+                                                renderNotes = renderNotes,
+                                                onRenderNotesClick = { renderNotes = !renderNotes }
+                                            )
+                                            ToolbarItem(
+                                                painter = painterResource(R.drawable.ic_round_edit_24),
+                                                toggled = viewModel.notesToggled,
+                                                onClick = { viewModel.toolbarClick(ToolBarItem.Note) },
+                                                onLongClick = {
+                                                    if (viewModel.gamePlaying) {
+                                                        localView.performHapticFeedback(
+                                                            HapticFeedbackConstants.VIRTUAL_KEY
+                                                        )
+                                                        viewModel.showNotesMenu = true
+                                                    }
+                                                }
+                                            )
+
+                                        }
                                         ToolbarItem(
                                             modifier = Modifier.weight(1f),
-                                            painter = painterResource(R.drawable.ic_lightbulb_stars_24),
-                                            onClick = { viewModel.toolbarClick(ToolBarItem.Hint) }
-                                        )
-                                    }
-
-                                    Box(
-                                        modifier = Modifier.weight(1f)
-                                    ) {
-                                        NotesMenu(
-                                            expanded = viewModel.showNotesMenu,
-                                            onDismiss = { viewModel.showNotesMenu = false },
-                                            onComputeNotesClick = { viewModel.computeNotes() },
-                                            onClearNotesClick = { viewModel.clearNotes() },
-                                            renderNotes = renderNotes,
-                                            onRenderNotesClick = { renderNotes = !renderNotes }
-                                        )
-                                        ToolbarItem(
-                                            painter = painterResource(R.drawable.ic_round_edit_24),
-                                            toggled = viewModel.notesToggled,
-                                            onClick = { viewModel.toolbarClick(ToolBarItem.Note) },
+                                            painter = painterResource(R.drawable.ic_eraser_24),
+                                            toggled = viewModel.eraseButtonToggled,
+                                            onClick = {
+                                                viewModel.toolbarClick(ToolBarItem.Remove)
+                                            },
                                             onLongClick = {
                                                 if (viewModel.gamePlaying) {
                                                     localView.performHapticFeedback(
                                                         HapticFeedbackConstants.VIRTUAL_KEY
                                                     )
-                                                    viewModel.showNotesMenu = true
+                                                    viewModel.toggleEraseButton()
                                                 }
                                             }
                                         )
-
-                                    }
-                                    ToolbarItem(
-                                        modifier = Modifier.weight(1f),
-                                        painter = painterResource(R.drawable.ic_eraser_24),
-                                        toggled = viewModel.eraseButtonToggled,
-                                        onClick = {
-                                            viewModel.toolbarClick(ToolBarItem.Remove)
-                                        },
-                                        onLongClick = {
-                                            if (viewModel.gamePlaying) {
-                                                localView.performHapticFeedback(
-                                                    HapticFeedbackConstants.VIRTUAL_KEY
-                                                )
-                                                viewModel.toggleEraseButton()
-                                            }
+                                        if (advancedHintEnabled) {
+                                            ToolbarItem(
+                                                modifier = Modifier.weight(1f),
+                                                painter = rememberVectorPainter(Icons.Rounded.AutoAwesome),
+                                                onClick = {
+                                                    if (viewModel.gamePlaying) {
+                                                        viewModel.getAdvancedHint()
+                                                    }
+                                                }
+                                            )
                                         }
-                                    )
-                                    if (advancedHintEnabled) {
-                                        ToolbarItem(
-                                            modifier = Modifier.weight(1f),
-                                            painter = rememberVectorPainter(Icons.Rounded.AutoAwesome),
-                                            onClick = {
-                                                if (viewModel.gamePlaying) {
-                                                    viewModel.getAdvancedHint()
-                                                }
-                                            }
-                                        )
                                     }
                                 }
+                            } else {
+                                // Game completed section
+                                val allRecords by viewModel.allRecords.collectAsStateWithLifecycle(
+                                    initialValue = emptyList()
+                                )
+                                AfterGameStats(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    difficulty = viewModel.gameDifficulty,
+                                    type = viewModel.gameType,
+                                    hintsUsed = viewModel.hintsUsed,
+                                    mistakesMade = viewModel.mistakesMade,
+                                    mistakesLimit = mistakesLimit,
+                                    mistakesLimitCount = viewModel.mistakesCount,
+                                    giveUp = viewModel.giveUp,
+                                    notesTaken = viewModel.notesTaken,
+                                    records = allRecords,
+                                    timeText = viewModel.timeText
+                                )
                             }
-                        } else {
-                            // Game completed section
-                            val allRecords by viewModel.allRecords.collectAsStateWithLifecycle(
-                                initialValue = emptyList()
-                            )
-                            AfterGameStats(
-                                modifier = Modifier.fillMaxWidth(),
-                                difficulty = viewModel.gameDifficulty,
-                                type = viewModel.gameType,
-                                hintsUsed = viewModel.hintsUsed,
-                                mistakesMade = viewModel.mistakesMade,
-                                mistakesLimit = mistakesLimit,
-                                mistakesLimitCount = viewModel.mistakesCount,
-                                giveUp = viewModel.giveUp,
-                                notesTaken = viewModel.notesTaken,
-                                records = allRecords,
-                                timeText = viewModel.timeText
-                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/kaajjo/libresudoku/ui/game/components/GameKeyboard.kt
+++ b/app/src/main/java/com/kaajjo/libresudoku/ui/game/components/GameKeyboard.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.unit.sp
 import com.kaajjo.libresudoku.core.qqwing.GameType
 import com.kaajjo.libresudoku.ui.theme.LibreSudokuTheme
 import com.kaajjo.libresudoku.ui.util.LightDarkPreview
+import kotlin.math.ceil
+import kotlin.math.sqrt
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -178,6 +180,62 @@ fun DefaultGameKeyboard(
                         },
                         selected = number == selected
                     )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SquareGameKeyboard(
+    modifier: Modifier = Modifier,
+    itemModifier: Modifier = Modifier,
+    remainingUses: List<Int>? = null,
+    onClick: (Int) -> Unit,
+    onLongClick: (Int) -> Unit,
+    size: Int,
+    selected: Int = 0
+) {
+    val numbers by remember(size) { mutableStateOf((1..size).toList()) }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        val chunkSize = ceil(sqrt(size.toDouble())).toInt()
+        val chunkedNumbers = numbers.chunked(chunkSize)
+        chunkedNumbers.forEachIndexed { index, chunked ->
+            AnimatedVisibility(
+                visible =
+                    (!remainingUses.isNullOrEmpty() && remainingUses.chunked(chunkSize)[index].any { it > 0 }) ||
+                            remainingUses == null
+            ) {
+                KeyboardRow {
+                    chunked.forEach { number ->
+                        val hide =
+                            remainingUses != null && (remainingUses.size > number && remainingUses[number - 1] <= 0)
+                        KeyboardItem(
+                            modifier = itemModifier
+                                .weight(1f)
+                                .alpha(if (hide) 0f else 1f),
+                            number = number,
+                            onClick = {
+                                if (!hide) {
+                                    onClick(number)
+                                }
+                            },
+                            onLongClick = {
+                                if (!hide) {
+                                    onLongClick(number)
+                                }
+                            },
+                            remainingUses = if (remainingUses != null && remainingUses.size >= number) {
+                                remainingUses[number - 1]
+                            } else {
+                                null
+                            },
+                            selected = number == selected
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/kaajjo/libresudoku/ui/gameshistory/savedgame/SavedGameScreen.kt
+++ b/app/src/main/java/com/kaajjo/libresudoku/ui/gameshistory/savedgame/SavedGameScreen.kt
@@ -1,5 +1,6 @@
 package com.kaajjo.libresudoku.ui.gameshistory.savedgame
 
+import android.content.res.Configuration
 import android.os.Build.VERSION.SDK_INT
 import android.widget.Toast
 import androidx.compose.animation.AnimatedContent
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -55,6 +57,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -151,198 +154,407 @@ fun SavedGameScreen(
         if (viewModel.savedGame != null && viewModel.boardEntity != null &&
             viewModel.parsedCurrentBoard.isNotEmpty() && viewModel.parsedInitialBoard.isNotEmpty()
         ) {
-            Column(
-                modifier = Modifier
-                    .padding(innerPadding)
-                    .fillMaxWidth()
-            ) {
-                val crossHighlight by viewModel.crossHighlight.collectAsStateWithLifecycle(
-                    initialValue = PreferencesConstants.DEFAULT_BOARD_CROSS_HIGHLIGHT
-                )
-                val fontSizeFactor by viewModel.fontSize.collectAsState(initial = PreferencesConstants.DEFAULT_FONT_SIZE_FACTOR)
-                val fontSizeValue by remember(fontSizeFactor) {
-                    mutableStateOf(
-                        viewModel.getFontSize(factor = fontSizeFactor)
-                    )
-                }
+            val configuration = LocalConfiguration.current
+            val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
 
-                val pagerState = rememberPagerState(pageCount = { 2 })
-                val pages = listOf(
-                    stringResource(R.string.saved_game_current),
-                    stringResource(R.string.saved_game_initial)
+            val crossHighlight by viewModel.crossHighlight.collectAsStateWithLifecycle(
+                initialValue = PreferencesConstants.DEFAULT_BOARD_CROSS_HIGHLIGHT
+            )
+            val fontSizeFactor by viewModel.fontSize.collectAsState(initial = PreferencesConstants.DEFAULT_FONT_SIZE_FACTOR)
+            val fontSizeValue by remember(fontSizeFactor) {
+                mutableStateOf(
+                    viewModel.getFontSize(factor = fontSizeFactor)
                 )
-                SecondaryTabRow(
-                    selectedTabIndex = pagerState.currentPage,
-                    divider = { },
+            }
+
+            val pagerState = rememberPagerState(pageCount = { 2 })
+            val pages = listOf(
+                stringResource(R.string.saved_game_current),
+                stringResource(R.string.saved_game_initial)
+            )
+
+            if (isLandscape) {
+                Row(
+                    modifier = Modifier
+                        .padding(innerPadding)
+                        .fillMaxSize()
                 ) {
-                    pages.forEachIndexed { index, title ->
-                        val coroutineScope = rememberCoroutineScope()
-                        Tab(
-                            selected = pagerState.currentPage == index,
-                            onClick = {
-                                coroutineScope.launch {
-                                    pagerState.animateScrollToPage(index, 0f)
-                                }
-                            },
-                            text = {
-                                Text(
-                                    text = title,
-                                    maxLines = 2,
-                                    overflow = TextOverflow.Ellipsis
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth(0.6f)
+                    ) {
+                        SecondaryTabRow(
+                            selectedTabIndex = pagerState.currentPage,
+                            divider = { },
+                        ) {
+                            pages.forEachIndexed { index, title ->
+                                val coroutineScope = rememberCoroutineScope()
+                                Tab(
+                                    selected = pagerState.currentPage == index,
+                                    onClick = {
+                                        coroutineScope.launch {
+                                            pagerState.animateScrollToPage(index, 0f)
+                                        }
+                                    },
+                                    text = {
+                                        Text(
+                                            text = title,
+                                            maxLines = 2,
+                                            overflow = TextOverflow.Ellipsis
+                                        )
+                                    }
                                 )
                             }
-                        )
-                    }
-                }
-                val boardScale = remember { Animatable(0.3f) }
-                LaunchedEffect(Unit) {
-                    boardScale.animateTo(
-                        targetValue = 1f,
-                        animationSpec = tween(
-                            durationMillis = 300,
-                            easing = LinearOutSlowInEasing
-                        )
-                    )
-                }
-                val boardModifier = Modifier
-                    .padding(10.dp)
-                    .scale(boardScale.value)
-                Column {
-                    HorizontalPager(
-                        state = pagerState,
-                        modifier = Modifier
-                            .wrapContentHeight()
-                            .padding(top = 8.dp)
-                    ) { page ->
-                        when (page) {
-                            0 -> Board(
-                                board = viewModel.parsedCurrentBoard,
-                                notes = viewModel.notes,
-                                modifier = boardModifier,
-                                mainTextSize = fontSizeValue,
-                                autoFontSize = fontSizeFactor == 0,
-                                selectedCell = Cell(-1, -1),
-                                onClick = { },
-                                crossHighlight = crossHighlight,
-                                cages = viewModel.killerCages
+                        }
+                        val boardScale = remember { Animatable(0.3f) }
+                        LaunchedEffect(Unit) {
+                            boardScale.animateTo(
+                                targetValue = 1f,
+                                animationSpec = tween(
+                                    durationMillis = 300,
+                                    easing = LinearOutSlowInEasing
+                                )
                             )
+                        }
+                        val boardModifier = Modifier
+                            .padding(10.dp)
+                            .scale(boardScale.value)
+                        Column {
+                            HorizontalPager(
+                                state = pagerState,
+                                modifier = Modifier
+                                    .wrapContentHeight()
+                                    .padding(top = 8.dp),
+                            ) { page ->
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.Center
+                                ) {
+                                    when (page) {
+                                        0 -> Board(
+                                            board = viewModel.parsedCurrentBoard,
+                                            notes = viewModel.notes,
+                                            modifier = boardModifier,
+                                            mainTextSize = fontSizeValue,
+                                            autoFontSize = fontSizeFactor == 0,
+                                            selectedCell = Cell(-1, -1),
+                                            onClick = { },
+                                            crossHighlight = crossHighlight,
+                                            cages = viewModel.killerCages
+                                        )
 
-                            1 -> Board(
-                                board = viewModel.parsedInitialBoard,
-                                modifier = boardModifier,
-                                mainTextSize = fontSizeValue,
-                                autoFontSize = fontSizeFactor == 0,
-                                selectedCell = Cell(-1, -1),
-                                onClick = { },
-                                crossHighlight = crossHighlight,
-                                cages = viewModel.killerCages
+                                        1 -> Board(
+                                            board = viewModel.parsedInitialBoard,
+                                            modifier = boardModifier,
+                                            mainTextSize = fontSizeValue,
+                                            autoFontSize = fontSizeFactor == 0,
+                                            selectedCell = Cell(-1, -1),
+                                            onClick = { },
+                                            crossHighlight = crossHighlight,
+                                            cages = viewModel.killerCages
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Column(
+                        modifier = Modifier
+                            .padding(horizontal = 12.dp)
+                            .fillMaxWidth()
+                    ) {
+                        val gameFolder by viewModel.gameFolder.collectAsStateWithLifecycle()
+                        gameFolder?.let {
+                            AssistChip(
+                                leadingIcon = {
+                                    Icon(
+                                        Icons.Outlined.Folder,
+                                        contentDescription = null
+                                    )
+                                },
+                                onClick = {
+                                    navigator.navigate(
+                                        ExploreFolderScreenDestination(
+                                            folderUid = it.uid
+                                        )
+                                    )
+                                },
+                                label = { Text(it.name) }
                             )
+                        }
+
+                        val textStyle = MaterialTheme.typography.bodyLarge
+
+                        val progressPercentage by viewModel.gameProgressPercentage.collectAsStateWithLifecycle()
+                        LaunchedEffect(viewModel.parsedCurrentBoard) { viewModel.countProgressFilled() }
+
+                        Text(
+                            text = stringResource(
+                                R.string.saved_game_progress_percentage,
+                                progressPercentage
+                            ),
+                            style = textStyle
+                        )
+
+
+                        viewModel.savedGame?.let { savedGame ->
+                            if (savedGame.startedAt != null) {
+                                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                    val startedAtDate by remember(savedGame) {
+                                        mutableStateOf(
+                                            savedGame.startedAt.format(dateTimeFormatter)
+                                        )
+                                    }
+                                    val startedAtTime by remember(savedGame) {
+                                        mutableStateOf(
+                                            savedGame.startedAt.format(DateTimeFormatter.ofPattern("HH:mm"))
+                                        )
+                                    }
+                                    Text(startedAtDate)
+                                    Text(startedAtTime)
+                                }
+                            }
+                        }
+
+                        Text(
+                            text = viewModel.savedGame?.let {
+                                when {
+                                    it.mistakes >= PreferencesConstants.MISTAKES_LIMIT -> stringResource(
+                                        R.string.saved_game_mistakes_limit
+                                    )
+
+                                    it.giveUp -> stringResource(R.string.saved_game_give_up)
+                                    it.completed && !it.canContinue -> stringResource(R.string.saved_game_completed)
+                                    else -> stringResource(R.string.saved_game_in_progress)
+                                }
+                            } ?: ""
+                        )
+
+                        Text(
+                            text = stringResource(
+                                R.string.saved_game_difficulty,
+                                stringResource(viewModel.boardEntity!!.difficulty.resName)
+                            ),
+                            style = textStyle
+                        )
+                        Text(
+                            text = stringResource(
+                                R.string.saved_game_type,
+                                stringResource(viewModel.boardEntity!!.type.resName)
+                            ),
+                            style = textStyle
+                        )
+                        Text(
+                            text = stringResource(
+                                R.string.saved_game_time,
+                                viewModel.savedGame!!.timer
+                                    .toKotlinDuration()
+                                    .toFormattedString()
+                            )
+                        )
+
+                        if (viewModel.savedGame!!.canContinue) {
+                            FilledTonalButton(
+                                modifier = Modifier.align(Alignment.CenterHorizontally),
+                                onClick = {
+                                    navigator.navigate(
+                                        GameScreenDestination(
+                                            gameUid = viewModel.savedGame!!.uid, playedBefore = true
+                                        )
+                                    )
+                                }
+                            ) {
+                                Text(stringResource(R.string.action_continue))
+                            }
                         }
                     }
                 }
-
-
+            } else {
                 Column(
                     modifier = Modifier
-                        .padding(horizontal = 12.dp)
+                        .padding(innerPadding)
                         .fillMaxWidth()
                 ) {
-                    val gameFolder by viewModel.gameFolder.collectAsStateWithLifecycle()
-                    gameFolder?.let {
-                        AssistChip(
-                            leadingIcon = {
-                                Icon(
-                                    Icons.Outlined.Folder,
-                                    contentDescription = null
-                                )
-                            },
-                            onClick = { navigator.navigate(ExploreFolderScreenDestination(folderUid = it.uid)) },
-                            label = { Text(it.name) }
+                    SecondaryTabRow(
+                        selectedTabIndex = pagerState.currentPage,
+                        divider = { },
+                    ) {
+                        pages.forEachIndexed { index, title ->
+                            val coroutineScope = rememberCoroutineScope()
+                            Tab(
+                                selected = pagerState.currentPage == index,
+                                onClick = {
+                                    coroutineScope.launch {
+                                        pagerState.animateScrollToPage(index, 0f)
+                                    }
+                                },
+                                text = {
+                                    Text(
+                                        text = title,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                }
+                            )
+                        }
+                    }
+                    val boardScale = remember { Animatable(0.3f) }
+                    LaunchedEffect(Unit) {
+                        boardScale.animateTo(
+                            targetValue = 1f,
+                            animationSpec = tween(
+                                durationMillis = 300,
+                                easing = LinearOutSlowInEasing
+                            )
                         )
                     }
+                    val boardModifier = Modifier
+                        .padding(10.dp)
+                        .scale(boardScale.value)
+                    Column {
+                        HorizontalPager(
+                            state = pagerState,
+                            modifier = Modifier
+                                .wrapContentHeight()
+                                .padding(top = 8.dp)
+                        ) { page ->
+                            when (page) {
+                                0 -> Board(
+                                    board = viewModel.parsedCurrentBoard,
+                                    notes = viewModel.notes,
+                                    modifier = boardModifier,
+                                    mainTextSize = fontSizeValue,
+                                    autoFontSize = fontSizeFactor == 0,
+                                    selectedCell = Cell(-1, -1),
+                                    onClick = { },
+                                    crossHighlight = crossHighlight,
+                                    cages = viewModel.killerCages
+                                )
 
-                    val textStyle = MaterialTheme.typography.bodyLarge
-
-                    val progressPercentage by viewModel.gameProgressPercentage.collectAsStateWithLifecycle()
-                    LaunchedEffect(viewModel.parsedCurrentBoard) { viewModel.countProgressFilled() }
-
-                    Text(
-                        text = stringResource(
-                            R.string.saved_game_progress_percentage,
-                            progressPercentage
-                        ),
-                        style = textStyle
-                    )
-
-
-                    viewModel.savedGame?.let { savedGame ->
-                        if (savedGame.startedAt != null) {
-                            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                                val startedAtDate by remember(savedGame) {
-                                    mutableStateOf(
-                                        savedGame.startedAt.format(dateTimeFormatter)
-                                    )
-                                }
-                                val startedAtTime by remember(savedGame) {
-                                    mutableStateOf(
-                                        savedGame.startedAt.format(DateTimeFormatter.ofPattern("HH:mm"))
-                                    )
-                                }
-                                Text(startedAtDate)
-                                Text(startedAtTime)
+                                1 -> Board(
+                                    board = viewModel.parsedInitialBoard,
+                                    modifier = boardModifier,
+                                    mainTextSize = fontSizeValue,
+                                    autoFontSize = fontSizeFactor == 0,
+                                    selectedCell = Cell(-1, -1),
+                                    onClick = { },
+                                    crossHighlight = crossHighlight,
+                                    cages = viewModel.killerCages
+                                )
                             }
                         }
                     }
 
-                    Text(
-                        text = viewModel.savedGame?.let {
-                            when {
-                                it.mistakes >= PreferencesConstants.MISTAKES_LIMIT -> stringResource(
-                                    R.string.saved_game_mistakes_limit
-                                )
 
-                                it.giveUp -> stringResource(R.string.saved_game_give_up)
-                                it.completed && !it.canContinue -> stringResource(R.string.saved_game_completed)
-                                else -> stringResource(R.string.saved_game_in_progress)
-                            }
-                        } ?: ""
-                    )
-
-                    Text(
-                        text = stringResource(
-                            R.string.saved_game_difficulty,
-                            stringResource(viewModel.boardEntity!!.difficulty.resName)
-                        ),
-                        style = textStyle
-                    )
-                    Text(
-                        text = stringResource(
-                            R.string.saved_game_type,
-                            stringResource(viewModel.boardEntity!!.type.resName)
-                        ),
-                        style = textStyle
-                    )
-                    Text(
-                        text = stringResource(
-                            R.string.saved_game_time,
-                            viewModel.savedGame!!.timer
-                                .toKotlinDuration()
-                                .toFormattedString()
-                        )
-                    )
-
-                    if (viewModel.savedGame!!.canContinue) {
-                        FilledTonalButton(
-                            modifier = Modifier.align(Alignment.CenterHorizontally),
-                            onClick = {
-                                navigator.navigate(
-                                    GameScreenDestination(
-                                        gameUid = viewModel.savedGame!!.uid, playedBefore = true
+                    Column(
+                        modifier = Modifier
+                            .padding(horizontal = 12.dp)
+                            .fillMaxWidth()
+                    ) {
+                        val gameFolder by viewModel.gameFolder.collectAsStateWithLifecycle()
+                        gameFolder?.let {
+                            AssistChip(
+                                leadingIcon = {
+                                    Icon(
+                                        Icons.Outlined.Folder,
+                                        contentDescription = null
                                     )
-                                )
+                                },
+                                onClick = {
+                                    navigator.navigate(
+                                        ExploreFolderScreenDestination(
+                                            folderUid = it.uid
+                                        )
+                                    )
+                                },
+                                label = { Text(it.name) }
+                            )
+                        }
+
+                        val textStyle = MaterialTheme.typography.bodyLarge
+
+                        val progressPercentage by viewModel.gameProgressPercentage.collectAsStateWithLifecycle()
+                        LaunchedEffect(viewModel.parsedCurrentBoard) { viewModel.countProgressFilled() }
+
+                        Text(
+                            text = stringResource(
+                                R.string.saved_game_progress_percentage,
+                                progressPercentage
+                            ),
+                            style = textStyle
+                        )
+
+
+                        viewModel.savedGame?.let { savedGame ->
+                            if (savedGame.startedAt != null) {
+                                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                    val startedAtDate by remember(savedGame) {
+                                        mutableStateOf(
+                                            savedGame.startedAt.format(dateTimeFormatter)
+                                        )
+                                    }
+                                    val startedAtTime by remember(savedGame) {
+                                        mutableStateOf(
+                                            savedGame.startedAt.format(DateTimeFormatter.ofPattern("HH:mm"))
+                                        )
+                                    }
+                                    Text(startedAtDate)
+                                    Text(startedAtTime)
+                                }
                             }
-                        ) {
-                            Text(stringResource(R.string.action_continue))
+                        }
+
+                        Text(
+                            text = viewModel.savedGame?.let {
+                                when {
+                                    it.mistakes >= PreferencesConstants.MISTAKES_LIMIT -> stringResource(
+                                        R.string.saved_game_mistakes_limit
+                                    )
+
+                                    it.giveUp -> stringResource(R.string.saved_game_give_up)
+                                    it.completed && !it.canContinue -> stringResource(R.string.saved_game_completed)
+                                    else -> stringResource(R.string.saved_game_in_progress)
+                                }
+                            } ?: ""
+                        )
+
+                        Text(
+                            text = stringResource(
+                                R.string.saved_game_difficulty,
+                                stringResource(viewModel.boardEntity!!.difficulty.resName)
+                            ),
+                            style = textStyle
+                        )
+                        Text(
+                            text = stringResource(
+                                R.string.saved_game_type,
+                                stringResource(viewModel.boardEntity!!.type.resName)
+                            ),
+                            style = textStyle
+                        )
+                        Text(
+                            text = stringResource(
+                                R.string.saved_game_time,
+                                viewModel.savedGame!!.timer
+                                    .toKotlinDuration()
+                                    .toFormattedString()
+                            )
+                        )
+
+                        if (viewModel.savedGame!!.canContinue) {
+                            FilledTonalButton(
+                                modifier = Modifier.align(Alignment.CenterHorizontally),
+                                onClick = {
+                                    navigator.navigate(
+                                        GameScreenDestination(
+                                            gameUid = viewModel.savedGame!!.uid, playedBefore = true
+                                        )
+                                    )
+                                }
+                            ) {
+                                Text(stringResource(R.string.action_continue))
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/kaajjo/libresudoku/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/kaajjo/libresudoku/ui/home/HomeScreen.kt
@@ -146,34 +146,38 @@ fun HomeScreen(
 
                 Spacer(Modifier.height(12.dp))
 
-                if (lastGame != null && !lastGame!!.completed) {
-                    Button(onClick = {
-                        if (lastGames.size <= 1) {
-                            lastGame?.let {
-                                navigator.navigate(
-                                    GameScreenDestination(
-                                        gameUid = it.uid,
-                                        playedBefore = true
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    if (lastGame != null && !lastGame!!.completed) {
+                        Button(onClick = {
+                            if (lastGames.size <= 1) {
+                                lastGame?.let {
+                                    navigator.navigate(
+                                        GameScreenDestination(
+                                            gameUid = it.uid,
+                                            playedBefore = true
+                                        )
                                     )
-                                )
+                                }
+                            } else {
+                                lastGamesBottomSheet = true
                             }
-                        } else {
-                            lastGamesBottomSheet = true
+                        }) {
+                            Text(stringResource(R.string.action_continue))
                         }
-                    }) {
-                        Text(stringResource(R.string.action_continue))
-                    }
-                    FilledTonalButton(onClick = {
-                        continueGameDialog = true
-                    }) {
-                        Text(stringResource(R.string.action_play))
-                    }
-                } else {
-                    Button(onClick = {
-                        viewModel.giveUpLastGame()
-                        viewModel.startGame()
-                    }) {
-                        Text(stringResource(R.string.action_play))
+                        FilledTonalButton(onClick = {
+                            continueGameDialog = true
+                        }) {
+                            Text(stringResource(R.string.action_play))
+                        }
+                    } else {
+                        Button(onClick = {
+                            viewModel.giveUpLastGame()
+                            viewModel.startGame()
+                        }) {
+                            Text(stringResource(R.string.action_play))
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/kaajjo/libresudoku/ui/learn/learnsudoku/LearnBasic.kt
+++ b/app/src/main/java/com/kaajjo/libresudoku/ui/learn/learnsudoku/LearnBasic.kt
@@ -1,6 +1,8 @@
 package com.kaajjo.libresudoku.ui.learn.learnsudoku
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -10,6 +12,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.kaajjo.libresudoku.R
@@ -99,21 +102,44 @@ fun LearnBasic(
             }
         }
 
-        Column(
-            modifier = Modifier.padding(horizontal = 12.dp)
-        ) {
-            Board(
-                board = board,
-                cellsToHighlight = if (step < stepsCell.size) stepsCell[step] else null,
-                onClick = { },
-                selectedCell = Cell(-1, -1)
-            )
-            TutorialBottomContent(
-                steps = steps,
-                step = step,
-                onPreviousClick = { if (step > 0) step-- },
-                onNextClick = { if (step < (steps.size - 1)) step++ }
-            )
+        val configuration = LocalConfiguration.current
+        val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+        if (isLandscape) {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp)
+            ) {
+                Board(
+                    board = board,
+                    cellsToHighlight = if (step < stepsCell.size) stepsCell[step] else null,
+                    onClick = { },
+                    selectedCell = Cell(-1, -1)
+                )
+                TutorialBottomContent(
+                    steps = steps,
+                    step = step,
+                    onPreviousClick = { if (step > 0) step-- },
+                    onNextClick = { if (step < (steps.size - 1)) step++ },
+                    modifier = Modifier.padding(horizontal = 8.dp)
+                )
+            }
+        } else {
+            Column(
+                modifier = Modifier.padding(horizontal = 12.dp)
+            ) {
+                Board(
+                    board = board,
+                    cellsToHighlight = if (step < stepsCell.size) stepsCell[step] else null,
+                    onClick = { },
+                    selectedCell = Cell(-1, -1)
+                )
+                TutorialBottomContent(
+                    steps = steps,
+                    step = step,
+                    onPreviousClick = { if (step > 0) step-- },
+                    onNextClick = { if (step < (steps.size - 1)) step++ }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/kaajjo/libresudoku/ui/learn/learnsudoku/LearnHiddenPairs.kt
+++ b/app/src/main/java/com/kaajjo/libresudoku/ui/learn/learnsudoku/LearnHiddenPairs.kt
@@ -1,6 +1,8 @@
 package com.kaajjo.libresudoku.ui.learn.learnsudoku
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -10,6 +12,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.kaajjo.libresudoku.R
@@ -119,22 +122,46 @@ fun LearnHiddenPairs(
             }
         }
 
-        Column(
-            modifier = Modifier.padding(horizontal = 12.dp)
-        ) {
-            Board(
-                board = board,
-                notes = notes,
-                cellsToHighlight = if (step < stepsCell.size) stepsCell[step] else null,
-                onClick = { },
-                selectedCell = Cell(-1, -1)
-            )
-            TutorialBottomContent(
-                steps = steps,
-                step = step,
-                onPreviousClick = { if (step > 0) step-- },
-                onNextClick = { if (step < (steps.size - 1)) step++ }
-            )
+        val configuration = LocalConfiguration.current
+        val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+        if (isLandscape) {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp)
+            ) {
+                Board(
+                    board = board,
+                    notes = notes,
+                    cellsToHighlight = if (step < stepsCell.size) stepsCell[step] else null,
+                    onClick = { },
+                    selectedCell = Cell(-1, -1)
+                )
+                TutorialBottomContent(
+                    steps = steps,
+                    step = step,
+                    onPreviousClick = { if (step > 0) step-- },
+                    onNextClick = { if (step < (steps.size - 1)) step++ },
+                    modifier = Modifier.padding(horizontal = 8.dp)
+                )
+            }
+        } else {
+            Column(
+                modifier = Modifier.padding(horizontal = 12.dp)
+            ) {
+                Board(
+                    board = board,
+                    notes = notes,
+                    cellsToHighlight = if (step < stepsCell.size) stepsCell[step] else null,
+                    onClick = { },
+                    selectedCell = Cell(-1, -1)
+                )
+                TutorialBottomContent(
+                    steps = steps,
+                    step = step,
+                    onPreviousClick = { if (step > 0) step-- },
+                    onNextClick = { if (step < (steps.size - 1)) step++ }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/kaajjo/libresudoku/ui/learn/learnsudoku/LearnNakedPairs.kt
+++ b/app/src/main/java/com/kaajjo/libresudoku/ui/learn/learnsudoku/LearnNakedPairs.kt
@@ -1,6 +1,8 @@
 package com.kaajjo.libresudoku.ui.learn.learnsudoku
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -10,6 +12,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.kaajjo.libresudoku.R
@@ -126,22 +129,46 @@ fun LearnNakedPairs(
             }
         }
 
-        Column(
-            modifier = Modifier.padding(horizontal = 12.dp)
-        ) {
-            Board(
-                board = board,
-                notes = notes,
-                cellsToHighlight = if (step < stepsCell.size) stepsCell[step] else null,
-                onClick = { },
-                selectedCell = Cell(-1, -1)
-            )
-            TutorialBottomContent(
-                steps = steps,
-                step = step,
-                onPreviousClick = { if (step > 0) step-- },
-                onNextClick = { if (step < (steps.size - 1)) step++ }
-            )
+        val configuration = LocalConfiguration.current
+        val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+        if (isLandscape) {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp)
+            ) {
+                Board(
+                    board = board,
+                    notes = notes,
+                    cellsToHighlight = if (step < stepsCell.size) stepsCell[step] else null,
+                    onClick = { },
+                    selectedCell = Cell(-1, -1)
+                )
+                TutorialBottomContent(
+                    steps = steps,
+                    step = step,
+                    onPreviousClick = { if (step > 0) step-- },
+                    onNextClick = { if (step < (steps.size - 1)) step++ },
+                    modifier = Modifier.padding(horizontal = 8.dp)
+                )
+            }
+        } else {
+            Column(
+                modifier = Modifier.padding(horizontal = 12.dp)
+            ) {
+                Board(
+                    board = board,
+                    notes = notes,
+                    cellsToHighlight = if (step < stepsCell.size) stepsCell[step] else null,
+                    onClick = { },
+                    selectedCell = Cell(-1, -1)
+                )
+                TutorialBottomContent(
+                    steps = steps,
+                    step = step,
+                    onPreviousClick = { if (step > 0) step-- },
+                    onNextClick = { if (step < (steps.size - 1)) step++ }
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
I added alternatives for screens that had problems with landscape orientation. I also made some changes to the Board composable and created a SquareGameKeyboard for use in landscape orientation.

This will close #29 and #82

GameScreen:
[Screenshot_20250607-201733_LibreSudoku](https://github.com/user-attachments/assets/f4f4a121-eb7e-4669-8ceb-568d9717899d)
[Screenshot_20250606-202523_LibreSudoku](https://github.com/user-attachments/assets/eafa0a80-1a79-416b-957b-8a37e21064a8)
[Screenshot_20250607-155505_LibreSudoku](https://github.com/user-attachments/assets/a8c06bf7-95a7-4287-8fc1-536d89044db2)
[Screenshot_20250607-201743_LibreSudoku](https://github.com/user-attachments/assets/0c64d8d8-04f9-4085-8921-9089b86c84dc)
SavedGameScreen:
[Screenshot_20250607-201709_LibreSudoku](https://github.com/user-attachments/assets/127cd58a-559a-49ab-a16e-546493ec3a90)
HomeScreen:
[Screenshot_20250607-201622_LibreSudoku](https://github.com/user-attachments/assets/d58495b8-6a46-4ec5-8bee-7a7659e00765)
LearnBasic:
[Screenshot_20250607-203137_LibreSudoku](https://github.com/user-attachments/assets/bae288d9-db5c-4a9a-8e4e-5c53dd089a80)
LearnHiddenPairs:
[Screenshot_20250607-203120_LibreSudoku](https://github.com/user-attachments/assets/cc66f61b-ac33-4678-a4b4-48814b4a2650)
LearnNakedPairs:
[Screenshot_20250607-203130_LibreSudoku](https://github.com/user-attachments/assets/f56b203d-8178-4e18-a513-8827f08dd550)
